### PR TITLE
 Parse `umask` as `u16` under BSD and MacOS

### DIFF
--- a/src/pid/status.rs
+++ b/src/pid/status.rs
@@ -192,6 +192,9 @@ named!(parse_status_state<State>,
           | tag!("Z (zombie)") => { |_| State::Zombie }));
 
 named!(parse_command<String>,   delimited!(tag!("Name:\t"),      parse_line,         line_ending));
+#[cfg(any(all(target_os = "android", target_arch = "arm"), target_os = "freebsd", target_os = "macos"))]
+named!(parse_umask<mode_t>,     delimited!(tag!("Umask:\t"),     parse_u16_octal,    line_ending));
+#[cfg(not(any(all(target_os = "android", target_arch = "arm"), target_os = "freebsd", target_os = "macos")))]
 named!(parse_umask<mode_t>,     delimited!(tag!("Umask:\t"),     parse_u32_octal,    line_ending));
 named!(parse_state<State>,      delimited!(tag!("State:\t"),     parse_status_state, line_ending));
 named!(parse_pid<pid_t>,        delimited!(tag!("Tgid:\t"),      parse_i32,          line_ending));


### PR DESCRIPTION
Signed-off-by: ice1000 <ice1000kotlin@foxmail.com>

Resolves tikv/tikv#4130