### PR TITLE
Remove rust 1.13.0 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 
 rust:
-- 1.13.0
 - stable
 - nightly
 


### PR DESCRIPTION
Address comments https://github.com/tikv/procinfo-rs/pull/9#issuecomment-529107952 and https://github.com/tikv/procinfo-rs/pull/9#issuecomment-529126621.
