### PR TITLE
provide public access to cpu.rs functions.

### DIFF
--- a/src/pid/cpu.rs
+++ b/src/pid/cpu.rs
@@ -99,7 +99,7 @@ named!(parse_cpu_info<Cpu>,
 /// Returns information about cpu line aggregated statistics.
 ///
 /// Very first line `cpu` aggregates the numbers in all of the other "cpuN" lines in `/proc/stat`.
-pub fn cpu_line_aggregated_entry() -> Result<Cpu> {
+fn cpu_line_aggregated_entry() -> Result<Cpu> {
     let data = fs::read_to_string("/proc/stat")?;
     let lines: Vec<&str> = data.lines().collect();
     let cpu_line_info = try!(map_result(parse_cpu_info(lines[0].as_bytes())));

--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -16,7 +16,7 @@ pub use pid::mountinfo::{Mountinfo, mountinfo, mountinfo_self, mountinfo_task};
 pub use pid::statm::{Statm, statm, statm_self, statm_task};
 pub use pid::status::{SeccompMode, Status, status, status_self, status_task};
 pub use pid::stat::{Stat, stat, stat_self, stat_task};
-pub use pid::cpu::{Cpu};
+pub use pid::cpu::{Cpu, cpu_count, cpu_period};
 
 /// The state of a process.
 #[derive(Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
changes adding new interface for proc/stat to calculate CPU time period, is already merged as part of : https://github.com/tikv/procinfo-rs/pull/9

During this PR, forgot to provide public access to the functions present in `cpu.rs`. Doing access changes as part of this PR.

This feature is to address: tikv/tikv#5008

